### PR TITLE
Add MPL 2.0 boilerplate notice to source files

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <div id="app" class="app-container">
     <!-- Skip to Content Link -->

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 @import "tailwindcss";
 @import "tw-animate-css";
 

--- a/components/ActiveContextComposer.vue
+++ b/components/ActiveContextComposer.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <!-- Unified Context Set Composition Interface -->
   <div class="w-full">

--- a/components/ContextSetListManager.vue
+++ b/components/ContextSetListManager.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <div class="bg-gradient-surface overflow-hidden backdrop-blur-sm">
     <!-- Header -->

--- a/components/FileContentModal.vue
+++ b/components/FileContentModal.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <Dialog v-model:open="isOpen">
     <DialogContent class="max-w-6xl max-h-[90vh] flex flex-col">

--- a/components/GlobalFilesManifestViewer.vue
+++ b/components/GlobalFilesManifestViewer.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <div class="space-y-4">
     <!-- Header -->

--- a/components/HowToUseModal.vue
+++ b/components/HowToUseModal.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <Dialog v-model:open="isOpen">
     <DialogContent class="max-w-4xl max-h-[80vh] overflow-y-auto">

--- a/components/MainInterface.vue
+++ b/components/MainInterface.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <div class="min-h-screen-dynamic">
     <div class="mx-auto px-4 sm:px-6 lg:px-8 mt-12 max-w-full lg:max-w-screen-xl xl:max-w-screen-2xl space-y-6 lg:space-y-8 py-4 lg:py-6">

--- a/components/ProjectFileBrowser.vue
+++ b/components/ProjectFileBrowser.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <div class="bg-gradient-surface rounded-lg border shadow-sophisticated overflow-hidden backdrop-blur-sm h-full">
     <!-- Content -->

--- a/components/ProjectHeader.vue
+++ b/components/ProjectHeader.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>  
   <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
     <div class="flex-1 min-w-0">

--- a/components/active-context-set/Editor.vue
+++ b/components/active-context-set/Editor.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <div class="bg-gradient-surface rounded-lg border shadow-sophisticated overflow-hidden backdrop-blur-sm h-full">
     <!-- No Active Context Set State -->

--- a/components/active-context-set/FilesList.vue
+++ b/components/active-context-set/FilesList.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <div class="space-y-4">
     <!-- Header -->

--- a/components/active-context-set/LineRangeSelectionModal.vue
+++ b/components/active-context-set/LineRangeSelectionModal.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <Dialog v-model:open="open">
     <DialogContent class="max-w-6xl max-h-[90vh] flex flex-col">

--- a/components/active-context-set/WorkflowEditor.vue
+++ b/components/active-context-set/WorkflowEditor.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <div class="space-y-4">
     <!-- Header with Add Step Button -->

--- a/components/landing/AudienceSection.vue
+++ b/components/landing/AudienceSection.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <!-- Who Is It For Section -->
   <section id="audience" class="py-20 bg-gradient-to-b from-background to-muted/10">

--- a/components/landing/BenefitsSection.vue
+++ b/components/landing/BenefitsSection.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <!-- Benefits Section -->
   <section id="benefits" class="py-20 bg-gradient-to-b from-muted/10 to-background">

--- a/components/landing/CtaSection.vue
+++ b/components/landing/CtaSection.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <!-- Secondary Call to Action Section -->
   <section id="cta" class="py-20 bg-gradient-to-br from-primary/5 via-secondary/5 to-primary/5">

--- a/components/landing/FaqSection.vue
+++ b/components/landing/FaqSection.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <!-- FAQ Section -->
   <section id="faq" class="py-20 bg-gradient-to-b from-background to-muted/10">

--- a/components/landing/FeaturesSection.vue
+++ b/components/landing/FeaturesSection.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <!-- How It Works/Features Section -->
   <section id="features" class="py-20 bg-gradient-to-b from-background to-muted/10">

--- a/components/landing/HeroSection.vue
+++ b/components/landing/HeroSection.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <!-- Hero Section -->
   <header id="hero" class="relative pt-32 pb-24 overflow-hidden">

--- a/components/landing/LandingFooter.vue
+++ b/components/landing/LandingFooter.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <!-- Footer Section -->
   <footer class="container-smart py-8 border-t border-muted-foreground/20">

--- a/components/landing/ProblemSection.vue
+++ b/components/landing/ProblemSection.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <!-- Problem/Challenge Section -->
   <section id="problem" class="py-20 bg-gradient-to-b from-background to-muted/10">

--- a/components/landing/SolutionSection.vue
+++ b/components/landing/SolutionSection.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <!-- Solution Section -->
   <section id="solution" class="py-20 bg-gradient-to-b from-muted/10 to-background">

--- a/components/project-file-browser/Search.vue
+++ b/components/project-file-browser/Search.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <div class="file-tree-search mb-3 space-y-3">
     <!-- Search Input -->

--- a/components/project-file-browser/Tree.vue
+++ b/components/project-file-browser/Tree.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <div class="file-tree relative">
     <!-- Search Component - Sticky -->

--- a/components/project-file-browser/TreeItem.vue
+++ b/components/project-file-browser/TreeItem.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <div>
     <div 

--- a/components/ui/FullScreenLoader.vue
+++ b/components/ui/FullScreenLoader.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <div
     v-if="isVisible"

--- a/components/ui/NotificationContainer.vue
+++ b/components/ui/NotificationContainer.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <Teleport to="body">
     <div 

--- a/components/ui/button/Button.vue
+++ b/components/ui/button/Button.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { Primitive, type PrimitiveProps } from 'reka-ui'

--- a/components/ui/button/index.ts
+++ b/components/ui/button/index.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import { cva, type VariantProps } from 'class-variance-authority'
 
 export { default as Button } from './Button.vue'

--- a/components/ui/card/Card.vue
+++ b/components/ui/card/Card.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { cn } from '@/lib/utils'

--- a/components/ui/card/CardAction.vue
+++ b/components/ui/card/CardAction.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { cn } from '@/lib/utils'

--- a/components/ui/card/CardContent.vue
+++ b/components/ui/card/CardContent.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { cn } from '@/lib/utils'

--- a/components/ui/card/CardDescription.vue
+++ b/components/ui/card/CardDescription.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { cn } from '@/lib/utils'

--- a/components/ui/card/CardFooter.vue
+++ b/components/ui/card/CardFooter.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { cn } from '@/lib/utils'

--- a/components/ui/card/CardHeader.vue
+++ b/components/ui/card/CardHeader.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { cn } from '@/lib/utils'

--- a/components/ui/card/CardTitle.vue
+++ b/components/ui/card/CardTitle.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { cn } from '@/lib/utils'

--- a/components/ui/card/index.ts
+++ b/components/ui/card/index.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 export { default as Card } from './Card.vue'
 export { default as CardAction } from './CardAction.vue'
 export { default as CardContent } from './CardContent.vue'

--- a/components/ui/dialog/Dialog.vue
+++ b/components/ui/dialog/Dialog.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import { DialogRoot, type DialogRootEmits, type DialogRootProps, useForwardPropsEmits } from 'reka-ui'
 

--- a/components/ui/dialog/DialogClose.vue
+++ b/components/ui/dialog/DialogClose.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import { DialogClose, type DialogCloseProps } from 'reka-ui'
 

--- a/components/ui/dialog/DialogContent.vue
+++ b/components/ui/dialog/DialogContent.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { reactiveOmit } from '@vueuse/core'

--- a/components/ui/dialog/DialogDescription.vue
+++ b/components/ui/dialog/DialogDescription.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { reactiveOmit } from '@vueuse/core'

--- a/components/ui/dialog/DialogFooter.vue
+++ b/components/ui/dialog/DialogFooter.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { cn } from '@/lib/utils'

--- a/components/ui/dialog/DialogHeader.vue
+++ b/components/ui/dialog/DialogHeader.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { cn } from '@/lib/utils'

--- a/components/ui/dialog/DialogOverlay.vue
+++ b/components/ui/dialog/DialogOverlay.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { reactiveOmit } from '@vueuse/core'

--- a/components/ui/dialog/DialogScrollContent.vue
+++ b/components/ui/dialog/DialogScrollContent.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { reactiveOmit } from '@vueuse/core'

--- a/components/ui/dialog/DialogTitle.vue
+++ b/components/ui/dialog/DialogTitle.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { reactiveOmit } from '@vueuse/core'

--- a/components/ui/dialog/DialogTrigger.vue
+++ b/components/ui/dialog/DialogTrigger.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import { DialogTrigger, type DialogTriggerProps } from 'reka-ui'
 

--- a/components/ui/dialog/index.ts
+++ b/components/ui/dialog/index.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 export { default as Dialog } from './Dialog.vue'
 export { default as DialogClose } from './DialogClose.vue'
 export { default as DialogContent } from './DialogContent.vue'

--- a/components/ui/input/Input.vue
+++ b/components/ui/input/Input.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { useVModel } from '@vueuse/core'

--- a/components/ui/input/index.ts
+++ b/components/ui/input/index.ts
@@ -1,1 +1,6 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 export { default as Input } from './Input.vue'

--- a/components/ui/textarea/Textarea.vue
+++ b/components/ui/textarea/Textarea.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { useVModel } from '@vueuse/core'

--- a/components/ui/textarea/index.ts
+++ b/components/ui/textarea/index.ts
@@ -1,1 +1,6 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 export { default as Textarea } from './Textarea.vue'

--- a/composables/useAccessibility.ts
+++ b/composables/useAccessibility.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import { ref, inject, onMounted, onUnmounted } from 'vue'
 
 export interface AccessibilityOptions {

--- a/composables/useAnalytics.ts
+++ b/composables/useAnalytics.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import { posthog } from 'posthog-js'
 
 export interface AnalyticsEvent {

--- a/composables/useAutoSave.ts
+++ b/composables/useAutoSave.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import { ref, computed, watch } from 'vue'
 import type { Ref } from 'vue'
 import { useNotifications } from './useNotifications'

--- a/composables/useLoadingStates.ts
+++ b/composables/useLoadingStates.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import { ref, computed, reactive } from 'vue'
 import { useNotifications } from './useNotifications'
 

--- a/composables/useNotifications.ts
+++ b/composables/useNotifications.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import { ref, reactive, nextTick } from 'vue'
 
 export interface Notification {

--- a/composables/useProjectStore.ts
+++ b/composables/useProjectStore.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 export interface FileTreeItem {
   name: string
   path: string

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 // @ts-check
 import withNuxt from './.nuxt/eslint.config.mjs'
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import tailwindcss from '@tailwindcss/vite'
 
 // https://nuxt.com/docs/api/configuration/nuxt-config

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 <template>
   <div class="mobile-safe-area min-h-screen-dynamic bg-gradient-to-b from-background via-muted/5 to-background">
     <!-- Enhanced Floating Navbar with Navigation -->

--- a/plugins/analytics.client.ts
+++ b/plugins/analytics.client.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 export default defineNuxtPlugin(() => {
   const { initializeAnalytics, trackPageView } = useAnalytics()
   

--- a/scripts/test-summary.js
+++ b/scripts/test-summary.js
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 #!/usr/bin/env node
 
 const fs = require('fs')

--- a/scripts/test-summary.mjs
+++ b/scripts/test-summary.mjs
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 #!/usr/bin/env node
 
 import fs from 'fs'

--- a/tests/components/ActiveContextComposer.nuxt.test.ts
+++ b/tests/components/ActiveContextComposer.nuxt.test.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 // @vitest-environment nuxt
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'

--- a/tests/components/ContextSetListManager.nuxt.test.ts
+++ b/tests/components/ContextSetListManager.nuxt.test.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 // @vitest-environment nuxt
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'

--- a/tests/components/FileContentModal.nuxt.test.ts
+++ b/tests/components/FileContentModal.nuxt.test.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 // @vitest-environment nuxt
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'

--- a/tests/components/GlobalFilesManifestViewer.nuxt.test.ts
+++ b/tests/components/GlobalFilesManifestViewer.nuxt.test.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 // @vitest-environment nuxt
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'

--- a/tests/components/ProjectFileBrowser.nuxt.test.ts
+++ b/tests/components/ProjectFileBrowser.nuxt.test.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 // @vitest-environment nuxt
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'

--- a/tests/components/active-context-set/Editor.nuxt.test.ts
+++ b/tests/components/active-context-set/Editor.nuxt.test.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import Editor from '~/components/active-context-set/Editor.vue'

--- a/tests/components/active-context-set/FilesList.nuxt.test.ts
+++ b/tests/components/active-context-set/FilesList.nuxt.test.ts
@@ -1,3 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import FilesList from '~/components/active-context-set/FilesList.vue'

--- a/tests/components/active-context-set/LineRangeSelectionModal.nuxt.test.ts
+++ b/tests/components/active-context-set/LineRangeSelectionModal.nuxt.test.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import LineRangeSelectionModal from '~/components/active-context-set/LineRangeSelectionModal.vue'

--- a/tests/components/active-context-set/WorkflowEditor.nuxt.test.ts
+++ b/tests/components/active-context-set/WorkflowEditor.nuxt.test.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import WorkflowEditor from '~/components/active-context-set/WorkflowEditor.vue'

--- a/tests/components/project-file-browser/Search.nuxt.test.ts
+++ b/tests/components/project-file-browser/Search.nuxt.test.ts
@@ -1,3 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import Search from '~/components/project-file-browser/Search.vue'

--- a/tests/components/project-file-browser/Tree.nuxt.test.ts
+++ b/tests/components/project-file-browser/Tree.nuxt.test.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import Tree from '~/components/project-file-browser/Tree.vue'

--- a/tests/components/project-file-browser/TreeItem.nuxt.test.ts
+++ b/tests/components/project-file-browser/TreeItem.nuxt.test.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import TreeItem from '~/components/project-file-browser/TreeItem.vue'

--- a/tests/composables/useAutoSave.nuxt.test.ts
+++ b/tests/composables/useAutoSave.nuxt.test.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 // @vitest-environment nuxt
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { ref, nextTick } from 'vue'

--- a/tests/composables/useLoadingStates.nuxt.test.ts
+++ b/tests/composables/useLoadingStates.nuxt.test.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 // @vitest-environment nuxt
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { watch, nextTick } from 'vue'

--- a/tests/composables/useNotifications.nuxt.test.ts
+++ b/tests/composables/useNotifications.nuxt.test.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 // @vitest-environment nuxt
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { useNotifications } from '~/composables/useNotifications'

--- a/tests/composables/useProjectStore.nuxt.test.ts
+++ b/tests/composables/useProjectStore.nuxt.test.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 // @vitest-environment nuxt
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useProjectStore } from '~/composables/useProjectStore'

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 import { vi } from 'vitest'
 
 // Mock window methods that might not be available in test environment

--- a/types/analytics.d.ts
+++ b/types/analytics.d.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 // Global types for analytics services
 declare global {
   interface Window {

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 // Global type declarations for File System Access API
 interface FileSystemHandle {
   readonly kind: 'file' | 'directory';


### PR DESCRIPTION
This commit adds the Mozilla Public License, v. 2.0 boilerplate notice to the beginning of all relevant source files in the repository.

The following file types were processed:
- .vue
- .ts
- .js
- .mjs
- .css

Files that already contained the notice were skipped. Configuration files, documentation, and other non-source files were excluded as per the MPL 2.0 guidelines.